### PR TITLE
Firebase Performance Plugin - Fix hook unzipAndCopyConfigurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-04-05
+- Fix: removeTraceAttribute renamed
 ## 2021-03-29
 - Fix: Fixed hook unzipAndCopyConfigurations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-03-29
+- Fix: Fixed hook unzipAndCopyConfigurations
+
 ## 2021-03-18
 - feature: added pipelines configuration (https://outsystemsrd.atlassian.net/browse/RMET-437)
 

--- a/hooks/configurations/unzipAndCopyConfigurations.js
+++ b/hooks/configurations/unzipAndCopyConfigurations.js
@@ -61,7 +61,7 @@ module.exports = function(context) {
     var destPath = path.join(context.opts.projectRoot, "platforms", platform, "app");
     if (utils.checkIfFolderExists(destPath)) {
       var destFilePath = path.join(destPath, fileName);
-      if(!utils.checkIfFolderExists(destPath)){
+      if(!utils.checkIfFolderExists(destFilePath)){
         utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
       }
     }

--- a/hooks/configurations/unzipAndCopyConfigurations.js
+++ b/hooks/configurations/unzipAndCopyConfigurations.js
@@ -5,8 +5,6 @@ var AdmZip = require("adm-zip");
 
 var utils = require("./utilities");
 
-var utilsApp = require("../utilities");
-
 var constants = {
   googleServices: "google-services"
 };
@@ -55,33 +53,21 @@ module.exports = function(context) {
   var sourceFilePath = path.join(targetPath, fileName);
   var destFilePath = path.join(context.opts.plugin.dir, fileName);
 
-  var androidPath =  "platforms/android/app";
-  var iOSPath = "platforms/ios/" + utilsApp.getAppName(context) + "/Resources";
-
-  var completeFilePath;
-
-  var isAndroid = platform.localeCompare("android");
-  var isIOS = platform.localeCompare("ios");
-
-  if(isAndroid == 0){ //android code
-    completeFilePath = path.join(context.opts.projectRoot, androidPath);
-  }
-  else if(isIOS == 0){ //iOS code
-    completeFilePath = path.join(context.opts.projectRoot, iOSPath);
-  }
-
   if(!utils.checkIfFolderExists(destFilePath)){
     utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
   }
 
+  /* I believe this is not necessary, because the files are already copied to the correct folder in the line above, so comment
   if (cordovaAbove7) {
-    if (utils.checkIfFolderExists(completeFilePath)) {
-      var destFilePath = path.join(completeFilePath, fileName);
-      if(!utils.checkIfFolderExists(destFilePath)){
+    var destPath = path.join(context.opts.projectRoot, "platforms", platform, "app");
+    if (utils.checkIfFolderExists(destPath)) {
+      var destFilePath = path.join(destPath, fileName);
+      if(!utils.checkIfFolderExists(destPath)){
         utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
       }
     }
   }
+  */
       
   return defer.promise;
 }

--- a/hooks/configurations/unzipAndCopyConfigurations.js
+++ b/hooks/configurations/unzipAndCopyConfigurations.js
@@ -57,7 +57,6 @@ module.exports = function(context) {
     utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
   }
 
-  /* I believe this is not necessary, because the files are already copied to the correct folder in the line above, so comment
   if (cordovaAbove7) {
     var destPath = path.join(context.opts.projectRoot, "platforms", platform, "app");
     if (utils.checkIfFolderExists(destPath)) {
@@ -67,7 +66,6 @@ module.exports = function(context) {
       }
     }
   }
-  */
       
   return defer.promise;
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <clobbers target="cordova.plugins.OSFirebasePerformance"/>
   </js-module>
 
-  <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#outsystems"/>
+  <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#fix/remove-hook-unzipAndCopy"/>
 
   <preference name="PERFORMANCE_MONITORING_ENABLED" default="true" />
   

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,7 @@
       </feature>
     </config-file>
     <!--<dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" commit="513e43f94ae94ad609d49f24e7dca23a4c358095" id="cordova-plugin-add-swift-support"/>-->
-    <dependency url=“https://github.com/agoncalvesos/cordova-plugin-add-swift-support” id=“cordova-plugin-add-swift-support”/>
+    <dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" id="cordova-plugin-add-swift-support"/>
 
      <config-file target="*-Info.plist" parent="FIREBASE_PERFORMANCE_COLLECTION_ENABLED">
             <string>$PERFORMANCE_MONITORING_ENABLED</string>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <clobbers target="cordova.plugins.OSFirebasePerformance"/>
   </js-module>
 
-  <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#fix/remove-hook-unzipAndCopy"/>
+  <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#outsystems"/>
 
   <preference name="PERFORMANCE_MONITORING_ENABLED" default="true" />
   

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,8 @@
         <param name="onload" value="$PERFORMANCE_MONITORING_ENABLED" />
       </feature>
     </config-file>
-    <dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" commit="513e43f94ae94ad609d49f24e7dca23a4c358095" id="cordova-plugin-add-swift-support"/>
+    <!--<dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" commit="513e43f94ae94ad609d49f24e7dca23a4c358095" id="cordova-plugin-add-swift-support"/>-->
+    <dependency url=“https://github.com/agoncalvesos/cordova-plugin-add-swift-support” id=“cordova-plugin-add-swift-support”/>
 
      <config-file target="*-Info.plist" parent="FIREBASE_PERFORMANCE_COLLECTION_ENABLED">
             <string>$PERFORMANCE_MONITORING_ENABLED</string>

--- a/src/ios/FirebasePerformancePlugin.swift
+++ b/src/ios/FirebasePerformancePlugin.swift
@@ -41,7 +41,7 @@ class FirebasePerformancePlugin {
         }
     }
     
-    func removeAttribute(traceName: String, attributeName: String) {
+    func removeTraceAttribute(traceName: String, attributeName: String) {
         if !traceName.isEmpty && !attributeName.isEmpty {
             if let trace = traces[traceName] {
                 trace.removeAttribute(attributeName)

--- a/src/ios/OSFirebasePerformance.swift
+++ b/src/ios/OSFirebasePerformance.swift
@@ -28,11 +28,11 @@ class OSFirebasePerformance : CDVPlugin {
         plugin.addTraceAttribute(traceName: traceName, attributeName: attributeName, value: value)
     }
 
-    @objc(removeAttribute:)
-    func removeAttribute(command: CDVInvokedUrlCommand) {
+    @objc(removeTraceAttribute:)
+    func removeTraceAttribute(command: CDVInvokedUrlCommand) {
         let traceName = command.arguments[0] as? String ?? ""
         let attributeName = command.arguments[1] as? String ?? ""
-        plugin.removeAttribute(traceName: traceName, attributeName: attributeName)
+        plugin.removeTraceAttribute(traceName: traceName, attributeName: attributeName)
     }
 
     @objc(incrementMetric:)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixed hook unzip and copy configurations to copy the google-services configurations files to the correct locations.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
We were having an issue when using the plugins in some applications where the MABS builds would try to copy the same file to the same directory more than once, which resulted in errors.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS builds all working and plugin working.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
