### PR TITLE
RMET-732 Updated Performance plugin version on Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-08-24
+- Updated Firebase plugin versions to 8.6.0 on iOS and 20.0.+ on Android [RMET-732](https://outsystemsrd.atlassian.net/browse/RMET-732)
+
 ## [1.0.1]
 
 ## 2021-07-22

--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
 
     <source-file src="src/android/com/outsystems/plugins/firebaseperformance/OSFirebasePerformance.java" target-dir="src/com/outsystems/plugins/firebaseperformance"/>
 
-    <framework src="com.google.firebase:firebase-perf:19.1.1" />
+    <framework src="com.google.firebase:firebase-perf:20.0.+" />
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
   </platform>
   
@@ -52,6 +52,11 @@
     <source-file src="src/ios/OSFirebasePerformance.swift"/>
     <source-file src="src/ios/FirebasePerformancePlugin.swift"/>
 
-    <framework src="Firebase/Performance" type="podspec" spec="~> 8.6.0"/>
+    <podspec>
+      <pods>
+        <pod name="Firebase/Performance" spec="~> 8.6.0" />
+      </pods>
+    </podspec>
+    
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
   
   <platform name="ios">
 
-    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="~> 8.4.0"/>
+    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="~> 8.6.0"/>
 
     <config-file parent="/*" target="config.xml">
       <feature name="OSFirebasePerformance">

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,6 +52,6 @@
     <source-file src="src/ios/OSFirebasePerformance.swift"/>
     <source-file src="src/ios/FirebasePerformancePlugin.swift"/>
 
-    <framework src="Firebase/Performance" type="podspec" spec="~> 7.0.0"/>
+    <framework src="Firebase/Performance" type="podspec" spec="~> 8.6.0"/>
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,9 @@
   </platform>
   
   <platform name="ios">
+
+    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="~> 8.4.0"/>
+
     <config-file parent="/*" target="config.xml">
       <feature name="OSFirebasePerformance">
         <param name="ios-package" value="OSFirebasePerformance"/>
@@ -53,10 +56,12 @@
     <source-file src="src/ios/FirebasePerformancePlugin.swift"/>
 
     <podspec>
-      <pods>
-        <pod name="Firebase/Performance" spec="~> 8.6.0" />
-      </pods>
+        <config>
+            <source url="https://cdn.cocoapods.org/" />
+        </config>
+        <pods>
+            <pod name="Firebase/Performance" spec="$IOS_FIREBASE_PERFORMANCE_VERSION" />
+        </pods>
     </podspec>
-    
   </platform>
 </plugin>


### PR DESCRIPTION
## Description
Updated Firebase library version to 8.6.0 on iOS, and 20.0.+ on Android

## Context
The original issue was extended to upgrade Firebase/Crashlytics version. Because of this, we also needed to update the remaining Firebase plugins.
https://outsystemsrd.atlassian.net/browse/RMET-732

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [X] iOS
- [ ] JavaScript

## Tests
Tested on MABS 7.1.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [X] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
