### PR TITLE
RMET-2441 :: raise firebase-core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+- Feat: update firebase core version (https://outsystemsrd.atlassian.net/browse/RMET-2451).
 
 ## [1.0.7]
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <clobbers target="cordova.plugins.OSFirebasePerformance"/>
   </js-module>
 
-  <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.1"/>
+  <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#2.0.0"/>
 
   <preference name="PERFORMANCE_MONITORING_ENABLED" default="true" />
   


### PR DESCRIPTION
## Description
This PR raises the version of [firebase core](https://github.com/OutSystems/cordova-outsystems-firebase-core). This new version introduces a breaking change to O11 Firebase Plugins: there's no need for google services file to be zipped, but they need to be present in the `resources` folder.

## Context
For more context, check [here](https://outsystemsrd.atlassian.net/browse/RMET-2451)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [x] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Screenshots 
When O11 wrappers update to this version, we need to update the extensibility configuration to:

```json 
"resources" : {
   "android": {
      "AndroidResource": {
        "src": "./www/google-services.json",
        "target": "app/google-services.json"
      }
    },
    "ios": {
      "IosResource": {
        "src": "./www/GoogleService-Info.plist",
        "target": "GoogleService-Info.plist"
      }
    }
 }
```

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
