### PR TITLE
RMET-2858 ::: iOS ::: Raise Pod Version to `8.15.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+### Fixes
+- Update Firebase/Performance pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-2858)
 
 ## [2.0.0]
 
@@ -24,6 +26,7 @@ The changes documented here do not include those from the original repository.
 ## [1.0.6]
 ### Fixes
 - Removed hook that adds swift support and added the plugin as dependecy. (https://outsystemsrd.atlassian.net/browse/RMET-1680)
+
 ## [1.0.5]
 ### 2022-06-22
 - Update 'add_swift_support' hook to the latest version.

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
   
   <platform name="ios">
 
-    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="~> 8.6.0"/>
+    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="8.15.0"/>
 
     <config-file parent="/*" target="config.xml">
       <feature name="OSFirebasePerformance">


### PR DESCRIPTION
## Description
- Raises Pod version to `8.15.0`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2858

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
