### PR TITLE
RMET-3274 ::: iOS ::: Update 3rd Party that Adds Privacy Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
-### Fixes
-- Update Firebase/Performance pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-2858)
+
+### Chores
+- Update `FirebasePerformance` iOS pod to version `10.23.0` (https://outsystemsrd.atlassian.net/browse/RMET-3274).
+- Update `Firebase/Performance` iOS pod to version `8.15.0` (https://outsystemsrd.atlassian.net/browse/RMET-2858).
 
 ## [2.0.0]
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
   
   <platform name="ios">
 
-    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="8.15.0"/>
+    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="10.23.0"/>
 
     <config-file parent="/*" target="config.xml">
       <feature name="OSFirebasePerformance">
@@ -62,8 +62,8 @@
         <config>
             <source url="https://cdn.cocoapods.org/" />
         </config>
-        <pods>
-            <pod name="Firebase/Performance" spec="$IOS_FIREBASE_PERFORMANCE_VERSION" />
+        <pods use-frameworks="true">
+            <pod name="FirebasePerformance" spec="$IOS_FIREBASE_PERFORMANCE_VERSION" />
         </pods>
     </podspec>
   </platform>

--- a/src/ios/FirebasePerformancePlugin.swift
+++ b/src/ios/FirebasePerformancePlugin.swift
@@ -1,12 +1,4 @@
-//
-//  FirebasePerformancePlugin.swift
-//  Firebase Sample App
-//
-//  Created by Carlos Correa on 12/03/2021.
-//
-
-import Foundation
-import Firebase
+import FirebasePerformance
 
 class FirebasePerformancePlugin {
     var traces: [String: Trace] = [:]


### PR DESCRIPTION
## Description
- Update 3rd party SDK version to `10.23.0`.
- Enable the `use_frameworks` flag for CocoaPods.
- Fix import errors.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3274

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed and all were successful.

## Firebase Sample App Privacy Report
[Firebase.Sample.App-PrivacyReport.pdf](https://github.com/OutSystems/cordova-outsystems-firebase-performance/files/14720516/Firebase.Sample.App-PrivacyReport.pdf)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
