### PR TITLE
RMET-3642 Firebase Performance - iOS - Configure FirebaseApp if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+
+### Fixes
+- (ios) Call `FirebaseApp.configure()` if necessary (https://outsystemsrd.atlassian.net/browse/RMET-3642).
+
 ## 2.1.2
 
 ### Chores

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,8 +9,6 @@
     <clobbers target="cordova.plugins.OSFirebasePerformance"/>
   </js-module>
 
-  <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#2.0.0"/>
-
   <preference name="PERFORMANCE_MONITORING_ENABLED" default="true" />
   
   <platform name="android">

--- a/src/ios/FirebasePerformancePlugin.swift
+++ b/src/ios/FirebasePerformancePlugin.swift
@@ -1,7 +1,13 @@
 import FirebasePerformance
+import FirebaseCore
 
 class FirebasePerformancePlugin {
     var traces: [String: Trace] = [:]
+    
+    func configureApp() {
+        guard FirebaseApp.app() == nil else { return }
+        FirebaseApp.configure()
+    }
     
     func starTrace(traceName: String){
         if !traceName.isEmpty {

--- a/src/ios/OSFirebasePerformance.swift
+++ b/src/ios/OSFirebasePerformance.swift
@@ -6,6 +6,7 @@ class OSFirebasePerformance : CDVPlugin {
     
     override func pluginInitialize() {
         plugin = FirebasePerformancePlugin()
+        plugin.configureApp()
     }
     
     @objc(startTrace:)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- While testing the Firebase Performance cordova plugin in an OutSystems iOS app with only this plugin, we found that when calling the startTrace function, the app was crashing because `FirebaseApp.configure()` had to be executed before trying to start the trace.
- Since this should be done as soon as the plugin is about to be used, we added the logic to call `FirebaseApp.configure` in the `pluginInitialize` function.
- Extra: this PR also removes the dependency to `cordova-outsystems-firebase-core`, which is not needed anymore, as that plugin doesn't contain any hooks anymore.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3642

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 11 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=aeef6415f39fc73f1a73a8343b4d1aa9c888903a&stg=prd

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
