### PR TITLE
RMET-3642 Firebase Performance - Add build action information

### DIFF
--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -1,0 +1,30 @@
+# Build Actions
+
+This folder contains .yaml files for configuring build actions to use in a plugin on ODC with Capacitor. The purpose of these build actions is to provide the same functionality as cordova hooks, but on a Capacitor shell.
+
+## Contents
+
+The file setPerformanceConfigurations.yaml contains two build actions:
+
+- Android specific. Adds the `<meta-data android:name="firebase_performance_collection_enabled" android:value="true" />` meta-data entry to the app's `AndroidManifest.xml`. This is necessary for the Firebase Performance plugin to work properly in Android.
+
+- iOS specific. Set `FIREBASE_PERFORMANCE_COLLECTION_ENABLED` to `true` in the app's Info.plist file. This is necessary for the Firebase Performance plugin to work properly in iOS.
+
+
+## Outsystems' Usage
+
+1. Copy the build action yaml file (which can contain multiple build actions inside) into the ODC Plugin, placing them in "Data" -> "Resources" and set "Deploy Action" to "Deploy to Target Directory", with target directory empty.
+2. Update the Plugin's Extensibility configuration to use the build action.
+
+```json
+{
+    "buildConfigurations": {
+        "buildAction": {
+            "config": $resources.buildActionFileName.yaml,
+            "parameters": {
+                // parameters go here; if there are no parameters then the block can be ommited
+            }
+        }
+    }
+}
+```

--- a/build-actions/setPerformanceConfigurations.yaml
+++ b/build-actions/setPerformanceConfigurations.yaml
@@ -1,0 +1,13 @@
+platforms:
+  android:
+    manifest:
+      - file: AndroidManifest.xml
+        target: manifest/application
+        inject: |
+          <meta-data android:name="firebase_performance_collection_enabled" android:value="true" />
+
+  ios:
+    plist:
+       - replace: false
+         entries:
+            - FIREBASE_PERFORMANCE_COLLECTION_ENABLED: "true"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds a new `build-actions` folder to the repo, adding information about the build actions used in the OutSystems plugin, to make the plugin compatible with a Capacitor shell (MABS 12).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3642

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
