### PR TITLE
feat(ios): add Swift Package Manager support and bump Firebase version to 10.29.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ xcuserdata
 !xcshareddata
 !xcschemes
 node_modules
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 2.3.0
+
+### Features
+- (ios): add Swift Package Manager support and bump `FirebasePerformance` to version `10.29.0` (https://outsystemsrd.atlassian.net/browse/RMET-5140).
+
 ## 2.2.2
 
 ### Chores

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
                 .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
             ],
-            path: "src/ios",
-            publicHeadersPath: ".")
+            path: "src/ios")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,11 @@ import PackageDescription
 
 let package = Package(
     name: "cordova-outsystems-firebase-performance",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(
             name: "cordova-outsystems-firebase-performance",
-            targets: ["FirebasePerformancePlugin"])
+            targets: ["cordova-outsystems-firebase-performance"])
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
@@ -15,11 +15,12 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "FirebasePerformancePlugin",
+            name: "cordova-outsystems-firebase-performance",
             dependencies: [
                 .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
             ],
-            path: "src/ios")
+            path: "src/ios"),
+            publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -2,12 +2,12 @@
 import PackageDescription
 
 let package = Package(
-    name: "cordova-outsystems-firebase-performance",
+    name: "com.outsystems.plugins.firebaseperformance",
     platforms: [.iOS(.v15)],
     products: [
         .library(
-            name: "cordova-outsystems-firebase-performance",
-            targets: ["cordova-outsystems-firebase-performance"])
+            name: "com.outsystems.plugins.firebaseperformance",
+            targets: ["com.outsystems.plugins.firebaseperformance"])
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
@@ -15,12 +15,12 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "cordova-outsystems-firebase-performance",
+            name: "com.outsystems.plugins.firebaseperformance",
             dependencies: [
                 .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
             ],
-            path: "src/ios"),
+            path: "src/ios",
             publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "cordova-outsystems-firebase-performance",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(
+            name: "cordova-outsystems-firebase-performance",
+            targets: ["FirebasePerformancePlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.29.0")
+    ],
+    targets: [
+        .target(
+            name: "FirebasePerformancePlugin",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
+            ],
+            path: "src/ios")
+    ]
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.firebaseperformance",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Plugin to support firebase performance monitoring",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,9 +28,9 @@
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
   </platform>
   
-  <platform name="ios">
+  <platform name="ios" package="swift">
 
-    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="10.23.0"/>
+    <preference name="IOS_FIREBASE_PERFORMANCE_VERSION" default="10.29.0"/>
 
     <config-file parent="/*" target="config.xml">
       <feature name="OSFirebasePerformance">
@@ -47,7 +47,7 @@
             <source url="https://cdn.cocoapods.org/" />
         </config>
         <pods use-frameworks="true">
-            <pod name="FirebasePerformance" spec="$IOS_FIREBASE_PERFORMANCE_VERSION" />
+            <pod name="FirebasePerformance" spec="$IOS_FIREBASE_PERFORMANCE_VERSION" nospm="true" />
         </pods>
     </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.firebaseperformance" version="2.2.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.firebaseperformance" version="2.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   
   <name>OSFirebasePerformance</name>
   <description>Plugin to support firebase performance monitoring</description>

--- a/src/ios/OSFirebasePerformance.swift
+++ b/src/ios/OSFirebasePerformance.swift
@@ -1,3 +1,7 @@
+#if canImport(Cordova)
+import Cordova
+#endif
+
 import UIKit
 
 @objc(OSFirebasePerformance)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Add Package.swift defining the SPM manifest (iOS 13+, firebase-ios-sdk 10.29.0)
- Mark ios platform with package="swift" in plugin.xml
- Bump IOS_FIREBASE_PERFORMANCE_VERSION default from 10.23.0 to 10.29.0
- Add nospm="true" to CocoaPods pod entry to avoid SPM conflicts

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

You can use different test apps to test that everything's still working with Firebase Performance - You can use our Firebase Sample App or an app that only has the Firebase Performance plugin. They both contain buttons to start and stop traces, as well as other plugin features. The bundle ID for both is `com.outsystems.rd.FirebaseAnalyticsSampleApp`, and you can check if the traces reach appear in the [Firebase Console](https://console.firebase.google.com/u/0/project/mobileecosystem-b80d4/performance/app/ios:com.outsystems.rd.FirebaseAnalyticsSampleApp/trends?time=24h).

- [MABS 12.1 Capacitor SPM](https://eng-test-us-01.outsystems.dev/apps/packagehistory?id=abd12c3a-3eaa-47e8-879d-503f9240cf17&stageid=ee84a6d3-b083-46fd-9118-358498476969) (requires Capacitor CLI version that is unreleased)
- [MABS 12.0 Capacitor CocoaPods](https://eng-mobile.outsystems.dev/apps/packagehistory?id=abd12c3a-3eaa-47e8-879d-503f9240cf17&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b)
- [MABS 12.0 Cordova](https://eng-mobile.outsystems.dev/apps/packagehistory?id=abd12c3a-3eaa-47e8-879d-503f9240cf17&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b)
- [MABS 11.2 Cordova](https://eng-mobile.outsystems.dev/apps/packagehistory?id=abd12c3a-3eaa-47e8-879d-503f9240cf17&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b)
- [Capacitor app with CocoaPods](https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps/tree/main/firebase-performance-capacitor-pods)

You can generate builds and test the apps directly, but let me know if you need the .ipa files to install directly.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
